### PR TITLE
[AIRFLOW-3251] KubernetesPodOperator does not use 'image_pull_secrets…

### DIFF
--- a/airflow/contrib/kubernetes/pod.py
+++ b/airflow/contrib/kubernetes/pod.py
@@ -54,6 +54,10 @@ class Pod:
     :type result: any
     :param image_pull_policy: Specify a policy to cache or always pull an image
     :type image_pull_policy: str
+    :param image_pull_secrets: Any image pull secrets to be given to the pod.
+                               If more than one secret is required, provide a
+                               comma separated list: secret_a,secret_b
+    :type image_pull_secrets: str
     :param affinity: A dict containing a group of affinity scheduling rules
     :type affinity: dict
     """

--- a/airflow/contrib/operators/kubernetes_pod_operator.py
+++ b/airflow/contrib/operators/kubernetes_pod_operator.py
@@ -45,6 +45,12 @@ class KubernetesPodOperator(BaseOperator):
     :param arguments: arguments of to the entrypoint. (templated)
         The docker image's CMD is used if this is not provided.
     :type arguments: list of str
+    :param image_pull_policy: Specify a policy to cache or always pull an image
+    :type image_pull_policy: str
+    :param image_pull_secrets: Any image pull secrets to be given to the pod.
+                               If more than one secret is required, provide a
+                               comma separated list: secret_a,secret_b
+    :type image_pull_secrets: str
     :param volume_mounts: volumeMounts for launched pod
     :type volume_mounts: list of VolumeMount
     :param volumes: volumes for launched pod. Includes ConfigMaps and PersistentVolumes
@@ -108,6 +114,7 @@ class KubernetesPodOperator(BaseOperator):
             pod.secrets = self.secrets
             pod.envs = self.env_vars
             pod.image_pull_policy = self.image_pull_policy
+            pod.image_pull_secrets = self.image_pull_secrets
             pod.annotations = self.annotations
             pod.resources = self.resources
             pod.affinity = self.affinity

--- a/tests/contrib/minikube/test_kubernetes_pod_operator.py
+++ b/tests/contrib/minikube/test_kubernetes_pod_operator.py
@@ -29,17 +29,21 @@ from airflow.contrib.kubernetes.volume_mount import VolumeMount
 from airflow.contrib.kubernetes.volume import Volume
 
 try:
-    check_call(["kubectl", "get", "pods"])
+    check_call(["/usr/local/bin/kubectl", "get", "pods"])
 except Exception as e:
-    raise unittest.SkipTest(
-        "Kubernetes integration tests require a minikube cluster;"
-        "Skipping tests {}".format(e)
-    )
+    if os.environ.get('KUBERNETES_VERSION'):
+        raise e
+    else:
+        raise unittest.SkipTest(
+            "Kubernetes integration tests require a minikube cluster;"
+            "Skipping tests {}".format(e)
+        )
 
 
 class KubernetesPodOperatorTest(unittest.TestCase):
 
-    def test_config_path_move(self):
+    @staticmethod
+    def test_config_path_move():
         new_config_path = '/tmp/kube_config'
         old_config_path = os.path.expanduser('~/.kube/config')
         shutil.copy(old_config_path, new_config_path)
@@ -80,7 +84,31 @@ class KubernetesPodOperatorTest(unittest.TestCase):
                                        cluster_context='default',
                                        config_file=file_path)
 
-    def test_working_pod(self):
+    @mock.patch("airflow.contrib.kubernetes.pod_launcher.PodLauncher.run_pod")
+    @mock.patch("airflow.contrib.kubernetes.kube_client.get_kube_client")
+    def test_image_pull_secrets_correctly_set(self, client_mock, launcher_mock):
+        from airflow.utils.state import State
+
+        fake_pull_secrets = "fakeSecret"
+        k = KubernetesPodOperator(
+            namespace='default',
+            image="ubuntu:16.04",
+            cmds=["bash", "-cx"],
+            arguments=["echo 10"],
+            labels={"foo": "bar"},
+            name="test",
+            task_id="task",
+            image_pull_secrets=fake_pull_secrets,
+            in_cluster=False,
+            cluster_context='default'
+        )
+        launcher_mock.return_value = (State.SUCCESS, None)
+        k.execute(None)
+        self.assertEqual(launcher_mock.call_args[0][0].image_pull_secrets,
+                         fake_pull_secrets)
+
+    @staticmethod
+    def test_working_pod():
         k = KubernetesPodOperator(
             namespace='default',
             image="ubuntu:16.04",
@@ -138,7 +166,8 @@ class KubernetesPodOperatorTest(unittest.TestCase):
         )
         k.execute(None)
 
-    def test_pod_affinity(self):
+    @staticmethod
+    def test_pod_affinity():
         affinity = {
             'nodeAffinity': {
                 'requiredDuringSchedulingIgnoredDuringExecution': {
@@ -169,7 +198,8 @@ class KubernetesPodOperatorTest(unittest.TestCase):
         )
         k.execute(None)
 
-    def test_logging(self):
+    @staticmethod
+    def test_logging():
         with mock.patch.object(PodLauncher, 'log') as mock_logger:
             k = KubernetesPodOperator(
                 namespace='default',
@@ -184,7 +214,8 @@ class KubernetesPodOperatorTest(unittest.TestCase):
             k.execute(None)
             mock_logger.info.assert_any_call(b"+ echo 10\n")
 
-    def test_volume_mount(self):
+    @staticmethod
+    def test_volume_mount():
         with mock.patch.object(PodLauncher, 'log') as mock_logger:
             volume_mount = VolumeMount('test-volume',
                                        mount_path='/root/mount_file',


### PR DESCRIPTION
Cherry-pick of this change: https://github.com/apache/airflow/commit/2b707aba3cf7aa78fff81065432e9fbebf3b15ca

This allows setting image_pull_secrets for a pod in the KubernetesPodOperator class which is necessary to pull docker images from a private repository. 

@dmitrig01